### PR TITLE
🚀 알림 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import PostDetail from '@pages/PostDetail/Post/Post'
 import MyPage from './pages/MyPage/MyPage'
 import { Routes, Route } from 'react-router-dom'
+import NotificationPage from './pages/NotificationPage/NotificationPage'
 
 const App = () => {
   return (
@@ -12,6 +13,10 @@ const App = () => {
       <Route
         path='/my'
         element={<MyPage />}
+      />
+      <Route 
+        path='/notification'
+        element={<NotificationPage />}
       />
     </Routes>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,10 +20,6 @@ const App = () => {
         element={<PostCreate />}
       />
       <Route
-        path='/create-post'
-        element={<PostCreate />}
-      />
-      <Route
         path='/notification'
         element={<NotificationPage />}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,10 @@ const App = () => {
         element={<PostCreate />}
       />
       <Route
+        path='/create-post'
+        element={<PostCreate />}
+      />
+      <Route
         path='/notification'
         element={<NotificationPage />}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import PostDetail from '@pages/PostDetail/Post/Post'
 import MyPage from './pages/MyPage/MyPage'
 import PostCreate from './pages/PostCreate/PostCreate'
 import { Routes, Route } from 'react-router-dom'
+import NotificationPage from './pages/NotificationPage/NotificationPage'
 
 const App = () => {
   return (
@@ -17,6 +18,10 @@ const App = () => {
       <Route
         path='/create-post'
         element={<PostCreate />}
+      />
+      <Route
+        path='/notification'
+        element={<NotificationPage />}
       />
     </Routes>
   )

--- a/src/pages/NotificationPage/NotificationContainer/NotificationContainer.css
+++ b/src/pages/NotificationPage/NotificationContainer/NotificationContainer.css
@@ -1,0 +1,17 @@
+.notification-container {
+  margin: 1rem;
+  display: flex;
+  flex-direction: column;
+
+  .period-name {
+    font-size: 18px;
+    font-weight: bold;
+    margin: 1rem;
+  }
+
+  .container-line {
+    width: 80%;
+    margin: 0 auto;
+    border: 1px solid #eeeeee;
+  }
+}

--- a/src/pages/NotificationPage/NotificationContainer/NotificationContainer.tsx
+++ b/src/pages/NotificationPage/NotificationContainer/NotificationContainer.tsx
@@ -1,0 +1,13 @@
+import './NotificationContainer.css'
+import NotificationItem from '../NotificationItem/NotificationItem'
+const NotificationContainer = ({period} : {period : string}) => {
+  return (
+    <div className='notification-container'>
+      <p className='period-name'>{period}</p>
+      <NotificationItem />
+      <NotificationItem />
+      <div className='container-line' />
+    </div>
+  )
+}
+export default NotificationContainer

--- a/src/pages/NotificationPage/NotificationContainer/NotificationContainer.tsx
+++ b/src/pages/NotificationPage/NotificationContainer/NotificationContainer.tsx
@@ -1,11 +1,23 @@
 import './NotificationContainer.css'
 import NotificationItem from '../NotificationItem/NotificationItem'
-const NotificationContainer = ({period} : {period : string}) => {
+import { Notification } from '@/typings/types'
+
+interface NotificationProps {
+  period: string
+  notifications: Notification[]
+}
+
+const NotificationContainer = (props: NotificationProps) => {
+  const { period, notifications } = props
   return (
     <div className='notification-container'>
       <p className='period-name'>{period}</p>
-      <NotificationItem />
-      <NotificationItem />
+      {notifications.map((notification, index) => (
+        <NotificationItem
+          key={index}
+          notification={notification}
+        />
+      ))}
       <div className='container-line' />
     </div>
   )

--- a/src/pages/NotificationPage/NotificationItem/NotificationItem.css
+++ b/src/pages/NotificationPage/NotificationItem/NotificationItem.css
@@ -1,15 +1,17 @@
 .notification-item-container {
   display: flex;
-  justify-content: center;
+  width: 90%;
   margin: 1rem;
 
   .notification-item {
     display: flex;
     justify-content: center;
+    width: 100%;
 
     .notification-text-container{
       display: flex;
       flex-direction: column;
+      width: 100%;
       margin-left: 1rem;
   
       .notification-text{

--- a/src/pages/NotificationPage/NotificationItem/NotificationItem.css
+++ b/src/pages/NotificationPage/NotificationItem/NotificationItem.css
@@ -8,21 +8,19 @@
     justify-content: center;
     width: 100%;
 
-    .notification-text-container{
+    .notification-text-container {
       display: flex;
       flex-direction: column;
       width: 100%;
       margin-left: 1rem;
-  
-      .notification-text{
+
+      .notification-text {
         font-size: 16px;
       }
-  
-      .notification-time{
+
+      .notification-time {
         font-size: 12px;
       }
     }
   }
-
-
 }

--- a/src/pages/NotificationPage/NotificationItem/NotificationItem.css
+++ b/src/pages/NotificationPage/NotificationItem/NotificationItem.css
@@ -1,0 +1,26 @@
+.notification-item-container {
+  display: flex;
+  justify-content: center;
+  margin: 1rem;
+
+  .notification-item {
+    display: flex;
+    justify-content: center;
+
+    .notification-text-container{
+      display: flex;
+      flex-direction: column;
+      margin-left: 1rem;
+  
+      .notification-text{
+        font-size: 16px;
+      }
+  
+      .notification-time{
+        font-size: 12px;
+      }
+    }
+  }
+
+
+}

--- a/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
+++ b/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
@@ -1,0 +1,20 @@
+import './NotificationItem.css'
+import Popular from '@assets/icons/notification_congratulation.svg?react'
+
+const NotificationItem = () => {
+  return (
+    <div className='notification-item-container'>
+      <div className='notification-item'>
+        <Popular />
+        <div className='notification-text-container'>
+          <p className='notification-text'>
+            “왜 만나는거야? 왜만나는거야?” 댓글에 좋아요가 달렸어요.
+          </p>
+          <p className='notification-time'>1시간</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default NotificationItem

--- a/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
+++ b/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
@@ -1,16 +1,38 @@
 import './NotificationItem.css'
+import { Notification } from '@/typings/types'
 import Popular from '@assets/icons/notification_congratulation.svg?react'
+import Comment from '@assets/icons/notification_comment.svg?react'
+import Like from '@assets/icons/notification_like.svg?react'
+import formatTime from '@/utils/formatTime'
 
-const NotificationItem = () => {
+interface NotificationItemProps {
+  notification: Notification
+}
+
+const NotificationItem = ({ notification }: NotificationItemProps) => {
+  const notificationIcon = () => {
+    if (notification.like !== undefined) {
+      return <Like />
+    } else if (notification.comment !== undefined) {
+      return <Comment />
+    }
+    return <Popular />
+  }
+  const notificationText = () => {
+    if (notification.like !== undefined) {
+      return `~에 좋아요가 달렸어요.`
+    } else if (notification.comment !== undefined) {
+      return `~에 댓글이 달렸어요.`
+    }
+  }
+  const notificationTime = formatTime(notification.createdAt)
   return (
     <div className='notification-item-container'>
       <div className='notification-item'>
-        <Popular />
+        {notificationIcon()}
         <div className='notification-text-container'>
-          <p className='notification-text'>
-            “왜 만나는거야? 왜만나는거야?” 댓글에 좋아요가 달렸어요.
-          </p>
-          <p className='notification-time'>1시간</p>
+          <p className='notification-text'>{notificationText()}</p>
+          <p className='notification-time'>{notificationTime}</p>
         </div>
       </div>
     </div>

--- a/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
+++ b/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
@@ -4,34 +4,45 @@ import Popular from '@assets/icons/notification_congratulation.svg?react'
 import Comment from '@assets/icons/notification_comment.svg?react'
 import Like from '@assets/icons/notification_like.svg?react'
 import formatTime from '@/utils/formatTime'
+import { useCallback } from 'react'
 
 interface NotificationItemProps {
   notification: Notification
 }
 
+interface NotificationData {
+  notificationIcon: JSX.Element
+  notificationText: string
+}
+
 const NotificationItem = ({ notification }: NotificationItemProps) => {
-  const notificationIcon = () => {
+  const setNotificationData = useCallback<() => NotificationData>(() => {
     if (notification.like !== undefined) {
-      return <Like />
+      return {
+        notificationIcon: <Like />,
+        notificationText: `"왜만나는거야? 왜만나는거야?" 게시글에 좋아요가 달렸어요.`,
+      }
     } else if (notification.comment !== undefined) {
-      return <Comment />
+      return {
+        notificationIcon: <Comment />,
+        notificationText: `"왜만나는거야? 왜만나는거야? 왜만나는거야? 왜만나는거야?"에 댓글이 달렸어요.`,
+      }
     }
-    return <Popular />
-  }
-  const notificationText = () => {
-    if (notification.like !== undefined) {
-      return `~에 좋아요가 달렸어요.`
-    } else if (notification.comment !== undefined) {
-      return `~에 댓글이 달렸어요.`
+    return {
+      notificationIcon: <Popular />,
+      notificationText: `축하합니다! 회원님의 게시글이 인기글에 선정되었어요!`,
     }
-  }
+  }, [])
+
+  const { notificationIcon, notificationText } = setNotificationData()
   const notificationTime = formatTime(notification.createdAt)
+
   return (
     <div className='notification-item-container'>
       <div className='notification-item'>
-        {notificationIcon()}
+        {notificationIcon}
         <div className='notification-text-container'>
-          <p className='notification-text'>{notificationText()}</p>
+          <p className='notification-text'>{notificationText}</p>
           <p className='notification-time'>{notificationTime}</p>
         </div>
       </div>

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -5,6 +5,8 @@ import NotificationContainer from './NotificationContainer/NotificationContainer
 import { Notification } from '@/typings/types'
 import axios from 'axios'
 import { useQuery } from '@tanstack/react-query'
+import formatTime from '@/utils/formatTime'
+import timeSeparation from '@/utils/timeSeparation'
 
 const getNotification = async (): Promise<Notification[]> => {
   const token =
@@ -40,25 +42,84 @@ const NotificationPage = () => {
   }
 
   console.log(data)
-  const unreadNotifications = data?.filter((notification) => !notification.seen)
+  const unreadNotifications: Notification[] | undefined = data?.filter(
+    (notification) => !notification.seen,
+  )
 
   console.log(unreadNotifications)
 
-  const likeNotification = data?.filter((notification) => notification?.like !== undefined)
-  const commentNotification = data?.filter((notification) => notification?.comment !== undefined)
+  const todayNotifications: Notification[] | undefined = []
+  const yesterdayNotifications: Notification[] | undefined = []
+  const weekNotifications: Notification[] | undefined = []
+  const pastNotifications: Notification[] | undefined = []
 
-  console.log('좋아요알림',likeNotification )
-  console.log('댓글알림',commentNotification )
+  data?.forEach((notification) => {
+    const timeNotification = timeSeparation(notification.createdAt)
+    if (timeNotification === 'TODAY') {
+      todayNotifications?.push(notification)
+    } else if (timeNotification === 'YESTERDAY') {
+      yesterdayNotifications?.push(notification)
+    } else if (timeNotification === 'WEEK') {
+      weekNotifications?.push(notification)
+    } else if (timeNotification === 'PAST') {
+      pastNotifications?.push(notification)
+    }
+  })
+
+  console.log('오늘', todayNotifications)
+  console.log('어제', yesterdayNotifications)
+  console.log('7일', weekNotifications)
+  console.log('과거', pastNotifications)
+
+  // const likeNotification = data?.filter(
+  //   (notification) => notification?.like !== undefined,
+  // )
+  // const commentNotification = data?.filter(
+  //   (notification) => notification?.comment !== undefined,
+  // )
+
+  // console.log('좋아요알림', likeNotification)
+  // console.log('댓글알림', commentNotification)
+
+  // console.log(
+  //   likeNotification?.map((notification) => formatTime(notification.createdAt)),
+  // )
 
   return (
     <DetailPageLayout
       pageName='notification'
       pageText='알림'
     >
-      <NotificationContainer period='읽지 않음' />
-      <NotificationContainer period='어제' />
-      <NotificationContainer period='최근 7일' />
-      <NotificationContainer period='이전 활동' />
+      {unreadNotifications && unreadNotifications.length > 1 && (
+        <NotificationContainer
+          period='읽지 않음'
+          notifications={unreadNotifications}
+        />
+      )}
+      {todayNotifications.length > 1 && (
+        <NotificationContainer
+          period='오늘'
+          notifications={todayNotifications}
+        />
+      )}
+      {yesterdayNotifications.length > 1 && (
+        <NotificationContainer
+          period='어제'
+          notifications={yesterdayNotifications}
+        />
+      )}
+      {weekNotifications.length > 1 && (
+        <NotificationContainer
+          period='최근 7일'
+          notifications={weekNotifications}
+        />
+      )}
+      {pastNotifications.length > 1 && (
+        <NotificationContainer
+          period='이전 활동'
+          notifications={pastNotifications}
+        />
+      )}
       <Navigator />
     </DetailPageLayout>
   )

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -5,7 +5,6 @@ import NotificationContainer from './NotificationContainer/NotificationContainer
 import { Notification } from '@/typings/types'
 import axios from 'axios'
 import { useQuery } from '@tanstack/react-query'
-import formatTime from '@/utils/formatTime'
 import timeSeparation from '@/utils/timeSeparation'
 
 const getNotification = async (): Promise<Notification[]> => {
@@ -41,21 +40,18 @@ const NotificationPage = () => {
     return <div>Error: {error.message}</div>
   }
 
-  console.log(data)
-  const unreadNotifications: Notification[] | undefined = data?.filter(
-    (notification) => !notification.seen,
-  )
-
-  console.log(unreadNotifications)
-
-  const todayNotifications: Notification[] | undefined = []
-  const yesterdayNotifications: Notification[] | undefined = []
-  const weekNotifications: Notification[] | undefined = []
-  const pastNotifications: Notification[] | undefined = []
+  const unreadNotifications: Notification[] = []
+  const todayNotifications: Notification[] = []
+  const yesterdayNotifications: Notification[] = []
+  const weekNotifications: Notification[] = []
+  const pastNotifications: Notification[] = []
 
   data?.forEach((notification) => {
     const timeNotification = timeSeparation(notification.createdAt)
-    if (timeNotification === 'TODAY') {
+
+    if (!notification.seen) {
+      unreadNotifications?.push(notification)
+    } else if (timeNotification === 'TODAY') {
       todayNotifications?.push(notification)
     } else if (timeNotification === 'YESTERDAY') {
       yesterdayNotifications?.push(notification)
@@ -65,25 +61,6 @@ const NotificationPage = () => {
       pastNotifications?.push(notification)
     }
   })
-
-  console.log('오늘', todayNotifications)
-  console.log('어제', yesterdayNotifications)
-  console.log('7일', weekNotifications)
-  console.log('과거', pastNotifications)
-
-  // const likeNotification = data?.filter(
-  //   (notification) => notification?.like !== undefined,
-  // )
-  // const commentNotification = data?.filter(
-  //   (notification) => notification?.comment !== undefined,
-  // )
-
-  // console.log('좋아요알림', likeNotification)
-  // console.log('댓글알림', commentNotification)
-
-  // console.log(
-  //   likeNotification?.map((notification) => formatTime(notification.createdAt)),
-  // )
 
   return (
     <DetailPageLayout
@@ -96,25 +73,25 @@ const NotificationPage = () => {
           notifications={unreadNotifications}
         />
       )}
-      {todayNotifications.length > 1 && (
+      {todayNotifications.length > 0 && (
         <NotificationContainer
           period='오늘'
           notifications={todayNotifications}
         />
       )}
-      {yesterdayNotifications.length > 1 && (
+      {yesterdayNotifications.length > 0 && (
         <NotificationContainer
           period='어제'
           notifications={yesterdayNotifications}
         />
       )}
-      {weekNotifications.length > 1 && (
+      {weekNotifications.length > 0 && (
         <NotificationContainer
           period='최근 7일'
           notifications={weekNotifications}
         />
       )}
-      {pastNotifications.length > 1 && (
+      {pastNotifications.length > 0 && (
         <NotificationContainer
           period='이전 활동'
           notifications={pastNotifications}

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -2,14 +2,58 @@ import DetailPageLayout from '@/layouts/DetailPageLayout/DetailPageLayout'
 import './NotificationPage.css'
 import Navigator from '@/components/Navigatior/Navigator'
 import NotificationContainer from './NotificationContainer/NotificationContainer'
+import { Notification } from '@/typings/types'
+import axios from 'axios'
+import { useQuery } from '@tanstack/react-query'
+
+const getNotification = async (): Promise<Notification[]> => {
+  const token =
+    '' //localStorage에서 가져오도록 추후 수정
+  try {
+    const response = await axios.get<Notification[]>(
+      'https://kdt.frontend.5th.programmers.co.kr:5001/notifications',
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    )
+    return response.data
+  } catch (error) {
+    console.error('알림 가져오기 오류:', error)
+    throw error
+  }
+}
 
 const NotificationPage = () => {
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['notifications'],
+    queryFn: getNotification,
+  })
+
+  if (isLoading) {
+    return <div>Loading...</div>
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>
+  }
+
+  console.log(data)
+  const unreadNotifications = data?.filter(
+    (notification) => notification.seen === false
+  )
+
+  console.log(unreadNotifications)
   return (
-    <DetailPageLayout pageName='notification' pageText='알림'>
-      <NotificationContainer period='읽지 않음'/>
-      <NotificationContainer period='어제'/>
-      <NotificationContainer period='최근 7일'/>
-      <NotificationContainer period='이전 활동'/>
+    <DetailPageLayout
+      pageName='notification'
+      pageText='알림'
+    >
+      <NotificationContainer period='읽지 않음' />
+      <NotificationContainer period='어제' />
+      <NotificationContainer period='최근 7일' />
+      <NotificationContainer period='이전 활동' />
       <Navigator />
     </DetailPageLayout>
   )

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -1,0 +1,18 @@
+import DetailPageLayout from '@/layouts/DetailPageLayout/DetailPageLayout'
+import './NotificationPage.css'
+import Navigator from '@/components/Navigatior/Navigator'
+import NotificationContainer from './NotificationContainer/NotificationContainer'
+
+const NotificationPage = () => {
+  return (
+    <DetailPageLayout pageName='notification' pageText='알림'>
+      <NotificationContainer period='읽지 않음'/>
+      <NotificationContainer period='어제'/>
+      <NotificationContainer period='최근 7일'/>
+      <NotificationContainer period='이전 활동'/>
+      <Navigator />
+    </DetailPageLayout>
+  )
+}
+
+export default NotificationPage

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -8,7 +8,7 @@ import { useQuery } from '@tanstack/react-query'
 
 const getNotification = async (): Promise<Notification[]> => {
   const token =
-    '' //localStorage에서 가져오도록 추후 수정
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7Il9pZCI6IjY2ZjkwMWNjMzYyN2UzNTYzZTMyNzIyNCIsImVtYWlsIjoibGVlQGdtYWlsLmNvbSJ9LCJpYXQiOjE3Mjc1OTQ5NTZ9.2dbp6G3LSvdVMCUCDRscDfmPJTjrsQiPgONM7AmQ7eA' //localStorage에서 가져오도록 추후 수정
   try {
     const response = await axios.get<Notification[]>(
       'https://kdt.frontend.5th.programmers.co.kr:5001/notifications',
@@ -40,11 +40,16 @@ const NotificationPage = () => {
   }
 
   console.log(data)
-  const unreadNotifications = data?.filter(
-    (notification) => notification.seen === false
-  )
+  const unreadNotifications = data?.filter((notification) => !notification.seen)
 
   console.log(unreadNotifications)
+
+  const likeNotification = data?.filter((notification) => notification?.like !== undefined)
+  const commentNotification = data?.filter((notification) => notification?.comment !== undefined)
+
+  console.log('좋아요알림',likeNotification )
+  console.log('댓글알림',commentNotification )
+
   return (
     <DetailPageLayout
       pageName='notification'

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -103,6 +103,7 @@ export interface Notification {
   _id: string
   author: User
   user: User | string
+  like?: string | null
   post?: string | null // 포스트 id (nullable)
   follow?: string // 팔로우 id (선택적)
   comment?: Comment // 선택적

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,0 +1,36 @@
+const formatTime = (timeString: string): string => {
+  const time = new Date(timeString)
+  const now = new Date()
+
+  const diffInMs = now.getTime() - time.getTime()
+  const diffInSec = Math.floor(diffInMs / 1000) // 초 차이
+  const diffInMin = Math.floor(diffInSec / 60) // 분 차이
+  const diffInHours = Math.floor(diffInMin / 60) // 시간 차이
+  const diffInDays = Math.floor(diffInHours / 24) // 일 차이
+  const diffInMonths = Math.floor(diffInDays / 30) // 월 차이
+  const diffInYears = Math.floor(diffInDays / 365) // 년 차이
+
+  /*
+  1분 이내 : 방금
+  첫 1시간 이내 : 00분 전
+  첫 24시간 이내 : 00시간 전
+  첫 1개월 이내 : 00일 전
+  첫 1년 이내 : 00달 전
+  추 후 : 00 년 전
+*/
+
+  if (diffInMin < 1) {
+    return '방금'
+  } else if (diffInMin < 60) {
+    return `${diffInMin}분 전`
+  } else if (diffInHours < 24) {
+    return `${diffInHours}시간 전`
+  } else if (diffInDays < 30) {
+    return `${diffInDays}일 전`
+  } else if (diffInMonths < 12) {
+    return `${diffInMonths}달 전`
+  }
+  return `${diffInYears}년 전`
+}
+
+export default formatTime


### PR DESCRIPTION
## 📌 과제 설명 
### 알림 페이지 구현

## 👩‍💻 요구 사항과 구현 내용 
### 🚀 알림 페이지 마크업 완료
  - **[읽지 않음 / 오늘 / 어제 / 최근 7일 / 이전 활동]** 으로 분류

### 🚀 알림 시간별 분리
  - createdAt를 포맷팅하여 위와 같이 분류되도록 구현
  - '읽지 않음'일 때 / '읽음' && 시간별로 분리

### 🚀 알림별 분리
  - 알림 종류에 따라 넘어오는 속성으로 분류
  - 알림별 아이콘, 문구 셋팅 완료
  - (우선 좋아요, 댓글만 분류했습니다.)

### 🚀 포스팅 시간 표시 로직 구현
  - 1분 이내 : 방금
  - 첫 1시간 이내 : 00분 전
  - 첫 24시간 이내 : 00시간 전
  - 첫 1개월 이내 : 00일 전
  - 첫 1년 이내 : 00달 전
  - 추 후 : 00 년 전

