### PR TITLE
🚀 수정 페이지 구현 완료

### DIFF
--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import Container from '@components/Conatiner/Container';
+import DetailPageLayout from '@/layouts/DetailPageLayout/DetailPageLayout';
 import './LoginPage.css';
 import Logo from '@assets/imgs/logo.png';
 import { useAuthStore } from '@store/authStore';
@@ -73,7 +73,7 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <Container>
+    <DetailPageLayout>
       <div className="page-wrapper">
         <header>
           <img src={Logo} className='logo' alt="Logo" />
@@ -107,7 +107,7 @@ const LoginPage: React.FC = () => {
           </form>
         </section>
       </div>
-    </Container>
+    </DetailPageLayout>
   );
 };
 

--- a/src/pages/PostCreate/AddImage/AddImage.tsx
+++ b/src/pages/PostCreate/AddImage/AddImage.tsx
@@ -1,15 +1,18 @@
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 import PostPageButton from '@/components/PostPageButton/PostPageButton'
 import './AddImage.css'
 
 interface AddImageProps {
+  isUpload: boolean
+  onChangeUpload: (isUpload: boolean) => void
+  onChangeImgDelete : (isImgDelete : boolean) => void
   postImage: File | null
   onChangeImage: (postImage: File | null) => void
 }
 
 const AddImage = (props: AddImageProps) => {
-  const { postImage, onChangeImage } = props
-  const [isUpload, setIsUpload] = useState<boolean>(false)
+  const { isUpload, onChangeUpload, onChangeImgDelete, postImage, onChangeImage } = props
+
   const imageInputRef = useRef<HTMLInputElement | null>(null)
   const handleAddImage = () => {
     imageInputRef.current?.click()
@@ -17,7 +20,8 @@ const AddImage = (props: AddImageProps) => {
 
   const handleDeleteImage = () => {
     onChangeImage(null)
-    setIsUpload(false)
+    onChangeUpload(false)
+    onChangeImgDelete(true)
     if (imageInputRef.current) {
       imageInputRef.current.value = ''
     }
@@ -27,7 +31,7 @@ const AddImage = (props: AddImageProps) => {
     const imgFile = e.target.files?.[0] || null
     if (imgFile) {
       onChangeImage(imgFile)
-      setIsUpload(true)
+      onChangeUpload(true)
     }
   }
   return (

--- a/src/pages/PostCreate/PostCreate.tsx
+++ b/src/pages/PostCreate/PostCreate.tsx
@@ -24,8 +24,11 @@ const PostCreate = () => {
     },
   })
   const [postImage, setPostImage] = useState<File | null>(null)
+  const [isPoll, setIsPoll] = useState<boolean>(false)
   const location = useLocation()
-  const editPostId : string | null = new URLSearchParams(location.search).get('postId')
+  const editPostId: string | null = new URLSearchParams(location.search).get(
+    'postId',
+  )
 
   const getPost = useCallback(async () => {
     const post = await getPostData(editPostId as string)
@@ -34,20 +37,21 @@ const PostCreate = () => {
     console.log(postData)
     setPostData((prevState) => ({
       ...prevState,
-      ['type'] : postData.title.type,
+      ['type']: postData.title.type,
       ['title']: postData.title.title,
-      ['body'] : postData.title.body,
-      ['poll'] : postData.title.poll
+      ['body']: postData.title.body,
+      ['poll']: postData.title.poll,
     }))
 
     const isPollAgree = postData.title.poll.agree
     const isPollDisAgree = postData.title.poll.disagree
     if (isPollAgree.length > 0 || isPollDisAgree.length > 0) {
+      setIsPoll(true)
     }
   }, [])
 
   useEffect(() => {
-    if(editPostId) {
+    if (editPostId) {
       getPost()
     }
   }, [editPostId])
@@ -93,6 +97,7 @@ const PostCreate = () => {
           onChangeImage={setPostImage}
         />
         <QuestionSelect
+          isPoll={isPoll}
           question={postData.poll.title}
           onChangeQuestion={handlePollChange('title')}
         />

--- a/src/pages/PostCreate/PostCreate.tsx
+++ b/src/pages/PostCreate/PostCreate.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import CategorySelect from './CategorySelect/CategorySelect'
 import PostContent from './PostContent/PostContent'
 import PostCreateButton from './PostCreateButton/PostCreateButton'
@@ -7,6 +7,9 @@ import AddImage from './AddImage/AddImage'
 import DetailPageLayout from '@/layouts/DetailPageLayout/DetailPageLayout'
 import './PostCreate.css'
 import { PostDetail } from '@/typings/types'
+import { useLocation } from 'react-router-dom'
+import { getPostData } from '@/utils/api'
+import formatPostData from '@/utils/formatPostData'
 
 const PostCreate = () => {
   const [postData, setPostData] = useState<PostDetail>({
@@ -21,6 +24,33 @@ const PostCreate = () => {
     },
   })
   const [postImage, setPostImage] = useState<File | null>(null)
+  const location = useLocation()
+  const editPostId : string | null = new URLSearchParams(location.search).get('postId')
+
+  const getPost = useCallback(async () => {
+    const post = await getPostData(editPostId as string)
+    console.log(post)
+    const postData = formatPostData(post)
+    console.log(postData)
+    setPostData((prevState) => ({
+      ...prevState,
+      ['type'] : postData.title.type,
+      ['title']: postData.title.title,
+      ['body'] : postData.title.body,
+      ['poll'] : postData.title.poll
+    }))
+
+    const isPollAgree = postData.title.poll.agree
+    const isPollDisAgree = postData.title.poll.disagree
+    if (isPollAgree.length > 0 || isPollDisAgree.length > 0) {
+    }
+  }, [])
+
+  useEffect(() => {
+    if(editPostId) {
+      getPost()
+    }
+  }, [editPostId])
 
   const handlePostChange = useCallback(
     (key: keyof PostDetail) => (value: string) => {

--- a/src/pages/PostCreate/PostCreateButton/PostCreateButton.tsx
+++ b/src/pages/PostCreate/PostCreateButton/PostCreateButton.tsx
@@ -3,15 +3,20 @@ import 'react-toastify/dist/ReactToastify.css'
 import './PostCreateButton.css'
 import { PostDetail } from '@/typings/types'
 import { useNavigate } from 'react-router-dom'
-import { createPost } from '@/utils/api'
+import { createPost, editPost } from '@/utils/api'
 
 interface PostCreateProps {
+  isEdit: boolean
+  isImgDelete: boolean
+  postId: string | null
   postData: PostDetail
   postImage: File | null
+  imagePublicId: string
 }
 
 const PostCreateButton = (props: PostCreateProps) => {
-  const { postData, postImage } = props
+  const { isEdit, isImgDelete, postId, postData, postImage, imagePublicId } =
+    props
   const navigate = useNavigate()
   const handlePostCreate = () => {
     if (postData.type === '카테고리') {
@@ -35,17 +40,55 @@ const PostCreateButton = (props: PostCreateProps) => {
     }
     newFormData.append('channelId', '66f6b3b7e5593e2a995daf1f')
     createPost(newFormData)
+
     navigate('/')
+  }
+
+  const handlePostEdit = () => {
+    if (!postData.title.trim()) {
+      toast.error('제목을 입력하세요')
+      return
+    } else if (!postData.body.trim()) {
+      toast.error('내용을 입력하세요')
+      return
+    } else if (!postData.poll.title) {
+      toast.error('질문을 선택하세요')
+      return
+    }
+
+    const newFormData = new FormData()
+    newFormData.append('postId', postId as string)
+    newFormData.append('title', JSON.stringify(postData))
+    if (postImage) {
+      newFormData.append('image', postImage)
+    }
+    if (isEdit && isImgDelete) {
+      newFormData.append('imageToDeletePublicId', imagePublicId)
+    }
+    newFormData.append('channelId', '66f6b3b7e5593e2a995daf1f')
+    editPost(newFormData)
+
+    navigate('/')
+    console.log('수정 완료')
   }
 
   return (
     <div className='post-create-button-container'>
-      <button
-        className='post-create-button'
-        onClick={handlePostCreate}
-      >
-        글쓰기
-      </button>
+      {isEdit ? (
+        <button
+          className='post-create-button'
+          onClick={handlePostEdit}
+        >
+          수정하기
+        </button>
+      ) : (
+        <button
+          className='post-create-button'
+          onClick={handlePostCreate}
+        >
+          글쓰기
+        </button>
+      )}
       <ToastContainer
         position='top-center' //알림 위치 설정
         autoClose={3000} // 자동 off 시간

--- a/src/pages/PostCreate/QuestionSelect/QuestionSelect.css
+++ b/src/pages/PostCreate/QuestionSelect/QuestionSelect.css
@@ -44,5 +44,12 @@
       color: #7d7d7d;
       background: none;
     }
+
+    .question-reselect-error {
+      margin: 1.5rem 0;
+      font-size: 14px;
+      color: #7d7d7d;
+      text-align: center;
+    }
   }
 }

--- a/src/pages/PostCreate/QuestionSelect/QuestionSelect.tsx
+++ b/src/pages/PostCreate/QuestionSelect/QuestionSelect.tsx
@@ -4,12 +4,13 @@ import BottomModal from '@/components/BottomModal/BottomModal'
 import QuestionModal from '../QuestionModal/QuestionModal'
 
 interface QuestionProps {
+  isPoll: boolean
   question: string
   onChangeQuestion: (question: string) => void
 }
 
 const QuestionSelect = (props: QuestionProps) => {
-  const { question, onChangeQuestion } = props
+  const { isPoll, question, onChangeQuestion } = props
   const [inputActive, setInputActive] = useState<boolean>(false)
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
   return (
@@ -25,12 +26,18 @@ const QuestionSelect = (props: QuestionProps) => {
         <div className='question-selected'>
           <p className='question-selected-title'>선택한 질문</p>
           <div className='question-selected-name'>{question}</div>
-          <button
-            className='question-reselect'
-            onClick={() => setIsModalOpen(true)}
-          >
-            질문 다시 선택
-          </button>
+          {!isPoll ? (
+            <button
+              className='question-reselect'
+              onClick={() => setIsModalOpen(true)}
+            >
+              질문 다시 선택
+            </button>
+          ) : (
+            <p className='question-reselect-error'>
+              투표가 이미 진행되어 질문을 수정할 수 없습니다.
+            </p>
+          )}
         </div>
       )}
       {isModalOpen && (

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -306,6 +306,26 @@ export const createPost = async (newPost: FormData) => {
   }
 }
 
+export const editPost = async (newPost: FormData) => {
+  const token = localStorage.getItem('token')
+  try {
+    const response = await axios.put(
+      'https://kdt.frontend.5th.programmers.co.kr:5001/posts/update',
+      newPost,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    )
+    return response.data
+  } catch (error) {
+    console.error('포스트 생성 오류:', error)
+    throw error
+  }
+}
+
 export const getNotification = async (): Promise<Notification[]> => {
   const token = localStorage.getItem('token')
   try {

--- a/src/utils/formatPostData.ts
+++ b/src/utils/formatPostData.ts
@@ -19,7 +19,7 @@ const formatPostData = (data: Post): FormattedPost => {
   const formattedComments = comments.map(({ comment, author, ...rest }) => ({
     ...rest,
     comment: parseIfString(comment),
-    author: { ...author, fullName: userData },
+    author: { ...author, fullName: parseIfString(author.fullName) },
   }))
 
   return {


### PR DESCRIPTION
## 📌 과제 설명 
### 수정페이지 구현 완료

## 👩‍💻 요구 사항과 구현 내용 
1. 기본 요구 사항
- 포스트 상세 페이지에서 [수정하기] 버튼 누르면 수정하기 페이지로 넘어감
- 넘어오는 postId로 기존에 작성했던 내용들이 유지되도록 구현
- 카테고리, 제목, 내용, 투표제목 받아오기
- 버튼을 '글쓰기'가 아닌 '수정하기'로 변경

2. 특별 요구 사항
- 투표가 이미 진행되고 있다면, 투표 제목을 바꿀 수 없도록 함
- Binary로 올라갔던 이미지를 다시 파일로 변환하여 받아옴
- 수정할 때 이미지 삭제 시 imageToDeletePublicId에 imagePublicId 넣음 (API 요구사항)

