### PR TITLE
🚀 마이 페이지 회원정보 수정 피드백

### DIFF
--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -2,9 +2,10 @@ import MainPageLayout from '@/layouts/MainPageLayout/MainPageLayout'
 import ProfileSection from './MyPageSection/ProfileSection'
 import AccountSection from './MyPageSection/AccountSection'
 import OtherSection from './MyPageSection/OtherSection'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { getUserData } from '@/utils/api'
+import useCustomMutation from '@/hooks/useCustomMutaition'
 
 const MyPage = () => {
   const [modalOpen, setModalOpen] = useState({
@@ -42,6 +43,13 @@ const MyPage = () => {
     return <div>{error.message}</div>
   }
 
+  const mutationFn = () => getUserData(userId as string)
+
+  // const { data, mutate } = useCustomMutation({
+  //   mutationFn,
+  //   queryKey: ['profile'],
+  // })
+
   return (
     <MainPageLayout>
       <section>
@@ -51,6 +59,7 @@ const MyPage = () => {
         <ProfileSection
           userData={data}
           isModalOpen={profileModal}
+          mutate={mutate}
           onChangeOpenModal={() => handleOpenModal('profileModal')}
           onChangeCloseModal={() => handleCloseModal('profileModal')}
         />

--- a/src/pages/MyPage/MyPageSection/ProfileSection.tsx
+++ b/src/pages/MyPage/MyPageSection/ProfileSection.tsx
@@ -6,6 +6,7 @@ import JoinDetail from '@/pages/JoinPage/JoinDetail/JoinDetail'
 import { updateUserData } from '@/utils/api'
 
 interface SectionProps {
+  mutate
   userData: User | undefined
   isModalOpen: boolean
   onChangeOpenModal: () => void
@@ -13,8 +14,15 @@ interface SectionProps {
 }
 
 const ProfileSection = (props: SectionProps) => {
-  const { userData, isModalOpen, onChangeOpenModal, onChangeCloseModal } = props
+  const {
+    mutate,
+    userData,
+    isModalOpen,
+    onChangeOpenModal,
+    onChangeCloseModal,
+  } = props
   const fullName = parseIfString(userData?.fullName as UserDetailData)
+  console.log(fullName)
   const { gender, ageGroup, mbti } = fullName
 
   const calculateAgeGroup = (birthDate: string) => {
@@ -37,6 +45,7 @@ const ProfileSection = (props: SectionProps) => {
     }
     const fullname = JSON.stringify(fullNameObject)
     updateUserData(fullname)
+    mutate()
     console.log('변경완료', gender, birthDate, mbti)
   }
 

--- a/src/pages/MyPage/MyPageSection/ProfileSection.tsx
+++ b/src/pages/MyPage/MyPageSection/ProfileSection.tsx
@@ -3,10 +3,9 @@ import InfoSection from '../Component/InfoSection/InfoSection'
 import '../MyPage.css'
 import { parseIfString } from '@/utils/formatPostData'
 import JoinDetail from '@/pages/JoinPage/JoinDetail/JoinDetail'
-import { updateUserData } from '@/utils/api'
 
 interface SectionProps {
-  mutate
+  mutate: (fullname: string) => void
   userData: User | undefined
   isModalOpen: boolean
   onChangeOpenModal: () => void
@@ -22,7 +21,6 @@ const ProfileSection = (props: SectionProps) => {
     onChangeCloseModal,
   } = props
   const fullName = parseIfString(userData?.fullName as UserDetailData)
-  console.log(fullName)
   const { gender, ageGroup, mbti } = fullName
 
   const calculateAgeGroup = (birthDate: string) => {
@@ -44,9 +42,7 @@ const ProfileSection = (props: SectionProps) => {
       mbti: mbti,
     }
     const fullname = JSON.stringify(fullNameObject)
-    updateUserData(fullname)
-    mutate()
-    console.log('변경완료', gender, birthDate, mbti)
+    mutate(fullname)
   }
 
   return (


### PR DESCRIPTION
## 📌 과제 설명 
마이 페이지 회원정보 수정 시 바로 안바뀌는 문제 수정

## 👩‍💻 요구 사항과 구현 내용 
마이페이지에서 프로필 수정 완료 시, 데이터 갱신과 함께 화면이 바로 바뀌도록 mutation 추가

