### PR TITLE
🚀 알림페이지 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,12 @@ import 'react-toastify/dist/ReactToastify.css'
 import Loading from '@pages/Loading/Loading' 
 import SplashScreen from '@pages/SplashScreen/SplashScreen'
 import PostCreate from './pages/PostCreate/PostCreate'
+import PostList from './pages/PostList/List'
 
 const NotFound = lazy(() => import('@pages/NotFound/NotFound'))
 const PostDetailPage = lazy(() => import('@pages/PostDetail/PostDetailPage'))
 const MyPage = lazy(() => import('./pages/MyPage/MyPage'))
 const NotificationPage = lazy(() => import('./pages/NotificationPage/NotificationPage'))
-const PostList = lazy(() => import('./pages/PostList/List'))
 const LoginPage = lazy(() => import('./pages/LoginPage/LoginPage'))
 const JoinPage = lazy(() => import('./pages/JoinPage/JoinPage'))
 const JoinCompletePage = lazy(() => import('./pages/JoinCompletePage/JoinCompletePage'))

--- a/src/pages/NotificationPage/NotificationContainer/NotificationContainer.css
+++ b/src/pages/NotificationPage/NotificationContainer/NotificationContainer.css
@@ -1,5 +1,6 @@
 .notification-container {
   margin: 1rem;
+  margin-top: 10px;
   display: flex;
   flex-direction: column;
 

--- a/src/pages/NotificationPage/NotificationItem/NotificationItem.css
+++ b/src/pages/NotificationPage/NotificationItem/NotificationItem.css
@@ -1,7 +1,11 @@
 .notification-item-container {
   display: flex;
-  width: 90%;
-  margin: 1rem;
+  padding: 1rem;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #eeeeee;
+  }
 
   .notification-item {
     display: flex;

--- a/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
+++ b/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
@@ -55,7 +55,7 @@ const NotificationItem = ({ notification }: NotificationItemProps) => {
 
   const handleNotification = () => {
     // putNotification() //읽음처리
-    navigate(`/post/${notification.post}`)
+    navigate(`/post/${notification.post}`, { state: { from: '/notification' } })
   }
   return (
     <div className='notification-item-container'>

--- a/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
+++ b/src/pages/NotificationPage/NotificationItem/NotificationItem.tsx
@@ -5,8 +5,9 @@ import Comment from '@assets/icons/notification_comment.svg?react'
 import Like from '@assets/icons/notification_like.svg?react'
 import formatTime from '@/utils/formatTime'
 import { useCallback, useEffect, useState } from 'react'
-import { getPostData, putNotification } from '@/utils/api'
+import { getPostData } from '@/utils/api'
 import { parseIfString } from '@/utils/formatPostData'
+import { useNavigate } from 'react-router-dom'
 
 interface NotificationItemProps {
   notification: Notification
@@ -19,6 +20,7 @@ interface NotificationData {
 
 const NotificationItem = ({ notification }: NotificationItemProps) => {
   const [postTitle, setPostTitle] = useState<string>('')
+  const navigate = useNavigate()
 
   const getPostTitle = async (notification: Notification) => {
     if (notification.post) {
@@ -44,7 +46,7 @@ const NotificationItem = ({ notification }: NotificationItemProps) => {
     }
     return {
       notificationIcon: <Popular />,
-      notificationText: `축하합니다! 회원님의 게시글 [${postTitle}]이 인기글에 선정되었어요!`,
+      notificationText: `[${postTitle}] 알림이 도착했습니다.`,
     }
   }, [notification, postTitle])
 
@@ -52,7 +54,8 @@ const NotificationItem = ({ notification }: NotificationItemProps) => {
   const notificationTime = formatTime(notification.createdAt)
 
   const handleNotification = () => {
-    putNotification()
+    // putNotification() //읽음처리
+    navigate(`/post/${notification.post}`)
   }
   return (
     <div className='notification-item-container'>

--- a/src/pages/NotificationPage/NotificationPage.css
+++ b/src/pages/NotificationPage/NotificationPage.css
@@ -1,0 +1,18 @@
+.read-button-container {
+  display: flex;
+  justify-content: flex-end;
+
+  .read-button {
+    width: 6rem;
+    height: 2rem;
+    margin-right: 1rem;
+    font-size: 14px;
+    background-color: #eeeeee;
+    border-radius: 5px;
+
+    &:active {
+      background-color: #7d7d7d;
+      color: #ffffff;
+    }
+  }
+}

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -3,15 +3,23 @@ import './NotificationPage.css'
 import Navigator from '@/components/Navigatior/Navigator'
 import NotificationContainer from './NotificationContainer/NotificationContainer'
 import { Notification } from '@/typings/types'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import timeSeparation from '@/utils/timeSeparation'
-import { getNotification } from '@/utils/api'
+import { getNotification, putNotification } from '@/utils/api'
 
 const NotificationPage = () => {
   const { data, error, isLoading } = useQuery({
     queryKey: ['notifications'],
     queryFn: () => getNotification(),
     // refetchInterval : 1000 //새로고침
+  })
+  const mutationFn = () => putNotification()
+  const queryClient = useQueryClient()
+  const { mutate } = useMutation({
+    mutationFn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] })
+    },
   })
 
   if (isLoading) {
@@ -48,6 +56,14 @@ const NotificationPage = () => {
       pageName='notification'
       pageText='알림'
     >
+      <div className='read-button-container'>
+        <button
+          className='read-button'
+          onClick={() => mutate()}
+        >
+          읽음 처리
+        </button>
+      </div>
       {unreadNotifications && unreadNotifications.length > 0 && (
         <NotificationContainer
           period='읽지 않음'

--- a/src/pages/PostDetail/PostDetailPage/index.tsx
+++ b/src/pages/PostDetail/PostDetailPage/index.tsx
@@ -9,11 +9,12 @@ import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 import { getPostData } from '@/utils/api'
 import { useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 import NotFound from '@/pages/NotFound/NotFound'
 import Loading from '@/pages/Loading/Loading'
 
 const PostDetailPage = () => {
+  const location = useLocation()
   const { postId } = useParams<{ postId: string }>()
 
   const { data, isLoading, isError } = useQuery({
@@ -34,6 +35,7 @@ const PostDetailPage = () => {
 
   if (data) {
     const post = formatPostData(data)
+    const isFromNotification = location.state?.from === '/notification'
 
     return (
       <>
@@ -43,7 +45,10 @@ const PostDetailPage = () => {
           autoClose={3000}
           limit={1}
         />
-        <DetailPageLayout pageName='post-detail'>
+        <DetailPageLayout
+          pageName='post-detail'
+          newPath={isFromNotification}
+        >
           <PostSection post={post} />
           <PostPoll
             post={post}


### PR DESCRIPTION
## 📌 과제 설명
알림페이지 및 포스트 상세페이지 네비게이터 수정

## 👩‍💻 요구 사항과 구현 내용 
- 알림페이지에서, 알림 누르면 해당 포스트로 이동하도록 구현
- 읽음 처리는 버튼을 새로 생성하여 한번에 처리하도록 함
- 알림페이지 -> 포스트페이지로 넘어갈 때, 뒤로가기 하면 '/'이 아닌 다시 뒤(알림페이지)로 가도록 수정

